### PR TITLE
Add unit tests for Helper utilities and FEN notation

### DIFF
--- a/src/test/java/HelperTests.java
+++ b/src/test/java/HelperTests.java
@@ -1,0 +1,50 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mxnik.forcechess.ChessLogic.Board;
+import org.mxnik.forcechess.ChessLogic.Moves.Helper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HelperTests {
+
+    @BeforeEach
+    public void setupBoardSideLen() {
+        Board.sideLen = 8;
+    }
+
+    @Test
+    public void testGetRowAndGetCol() {
+        assertEquals(0, Helper.getRow(0));
+        assertEquals(0, Helper.getCol(0));
+
+        assertEquals(3, Helper.getRow(27));
+        assertEquals(3, Helper.getCol(27));
+
+        assertEquals(7, Helper.getRow(63));
+        assertEquals(7, Helper.getCol(63));
+    }
+
+    @Test
+    public void testDistanceLeftAndRightBorders() {
+        assertEquals(0, Helper.distanceLeftB(0));
+        assertEquals(7, Helper.distanceRightB(0));
+
+        assertEquals(3, Helper.distanceLeftB(27));
+        assertEquals(4, Helper.distanceRightB(27));
+
+        assertEquals(7, Helper.distanceLeftB(63));
+        assertEquals(0, Helper.distanceRightB(63));
+    }
+
+    @Test
+    public void testDistanceTopAndBottomBorders() {
+        assertEquals(64, Helper.distanceTopB(0));
+        assertEquals(0, Helper.distanceBottomB(0));
+
+        assertEquals(40, Helper.distanceTopB(27));
+        assertEquals(24, Helper.distanceBottomB(27));
+
+        assertEquals(8, Helper.distanceTopB(63));
+        assertEquals(56, Helper.distanceBottomB(63));
+    }
+}

--- a/src/test/java/NotationTests.java
+++ b/src/test/java/NotationTests.java
@@ -1,11 +1,62 @@
 import org.junit.jupiter.api.Test;
+import org.mxnik.forcechess.ChessLogic.Notation.FenException;
 import org.mxnik.forcechess.ChessLogic.Notation.FenNotation;
+import org.mxnik.forcechess.ChessLogic.Pieces.Piece;
+import org.mxnik.forcechess.ChessLogic.Pieces.PieceTypes;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NotationTests {
 
     @Test
-    public void testFenConversion(){
-        //full String rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR  w KQkq - 0 1
-        FenNotation.readFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR", 8);
+    public void testReadFenParsesStartingPosition() {
+        Piece[] board = FenNotation.readFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR", 8);
+
+        assertNotNull(board);
+        assertEquals(64, board.length);
+
+        // White back rank (index 0..7)
+        assertEquals(PieceTypes.ROOK, board[0].getType());
+        assertEquals(0, board[0].getColor());
+        assertEquals(PieceTypes.KING, board[4].getType());
+        assertEquals(0, board[4].getColor());
+
+        // Black back rank (index 56..63)
+        assertEquals(PieceTypes.ROOK, board[56].getType());
+        assertEquals(1, board[56].getColor());
+        assertEquals(PieceTypes.KING, board[60].getType());
+        assertEquals(1, board[60].getColor());
+
+        // Middle board squares should be empty
+        assertSame(Piece.emptyPiece, board[27]);
+        assertSame(Piece.emptyPiece, board[36]);
+    }
+
+    @Test
+    public void testReadFenRejectsIllegalCharacter() {
+        FenException ex = assertThrows(FenException.class, () -> FenNotation.readFen("7x/8/8/8/8/8/8/8", 8));
+        assertTrue(ex.getMessage().contains("Illegal Char"));
+    }
+
+    @Test
+    public void testReadFenRejectsIncompleteFen() {
+        FenException ex = assertThrows(FenException.class, () -> FenNotation.readFen("8/8/8/8/8/8/8", 8));
+        assertTrue(ex.getMessage().contains("Fen isn't complete"));
+    }
+
+    @Test
+    public void testReadFenRejectsInvalidRowWidth() {
+        FenException ex = assertThrows(FenException.class, () -> FenNotation.readFen("7/8/8/8/8/8/8/8", 8));
+        assertTrue(ex.getMessage().contains("don't match the sidelen"));
+    }
+
+    @Test
+    public void testWriteFenCurrentBehaviorReturnsNullLiteral() {
+        Piece[] board = new Piece[64];
+        for (int i = 0; i < board.length; i++) {
+            board[i] = Piece.emptyPiece;
+        }
+
+        assertEquals("null", FenNotation.writeFen(board));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide unit coverage for board helper utilities (`getRow`, `getCol`, border-distance helpers) to catch index/geometry regressions.
- Exercise `FenNotation` read path and edge cases and cover the current `writeFen` behavior so the unimplemented method remains tested.

### Description
- Added `src/test/java/HelperTests.java` which sets `Board.sideLen` in `@BeforeEach` and tests `getRow`, `getCol`, `distanceLeftB`, `distanceRightB`, `distanceTopB`, and `distanceBottomB` on representative indices.
- Expanded `src/test/java/NotationTests.java` to include `testReadFenParsesStartingPosition`, `testReadFenRejectsIllegalCharacter`, `testReadFenRejectsIncompleteFen`, `testReadFenRejectsInvalidRowWidth`, and `testWriteFenCurrentBehaviorReturnsNullLiteral` using `Piece`, `Piece.emptyPiece`, and `PieceTypes` assertions.
- No production code was modified; tests rely on existing `FenNotation.readFen`, `FenNotation.writeFen`, `Piece`, and `Board` APIs.

### Testing
- Attempted to run `mvn test -q` in the repository, but the test run could not complete due to a Maven artifact resolution error (HTTP 403 when fetching `maven-resources-plugin`).
- No automated test results are available from this environment because of the dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921742a3a88324b3700794a9001e22)