### PR TITLE
Refactor piece move generation to populate MoveList

### DIFF
--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Board.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Board.java
@@ -71,9 +71,7 @@ public class Board {
                 continue;
             }
 
-            moveList.startPiece();
-            moveList.startDirection();
-            moveList.addMoves(board[i].getMoves(i));
+            board[i].getMoves(i, moveList);
 
         }
     }

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Bishop.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Bishop.java
@@ -1,6 +1,7 @@
 package org.mxnik.forcechess.ChessLogic.Pieces;
 
 import org.mxnik.forcechess.ChessLogic.Board;
+import org.mxnik.forcechess.ChessLogic.Moves.MoveList;
 
 import java.lang.Math;
 
@@ -26,12 +27,10 @@ public class Bishop extends Piece {
     }
 
     @Override
-    public byte[] getMoves(int pos) {
+    public void getMoves(int pos, MoveList moveList) {
         // code shaut hässlich aus ist aber nicht so uneffizient.
         // läuft immer noch O(N)
-
-        byte[] finalMs = new byte[moveSet.length];
-        int movePtr = 0;
+        moveList.startPiece();
 
         int dLeft = distanceLeftB(pos);
         int dTop = distanceTopB(pos);
@@ -40,25 +39,25 @@ public class Bishop extends Piece {
 
         // lönge der Diagonale ist das minimum zwischen den seiten
 
+        moveList.startDirection();
         for (int i = 1; i <= Math.min(dLeft, dTop); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * UP_L.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * UP_L.offset));
         }
+
+        moveList.startDirection();
         for (int i = 1; i <= (Math.min(dRight, dTop)); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * UP_R.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * UP_R.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= Math.min(dBott, dRight); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * DOWN_R.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * DOWN_R.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= Math.min(dBott, dLeft); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * DOWN_L.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * DOWN_L.offset));
         }
-        return finalMs;
     }
 
     public boolean isValidMove(int from, int to){

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Pawn.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Pawn.java
@@ -1,5 +1,6 @@
 package org.mxnik.forcechess.ChessLogic.Pieces;
 
+import org.mxnik.forcechess.ChessLogic.Moves.MoveList;
 import org.mxnik.forcechess.Util.Helper;
 import org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
 
@@ -61,14 +62,16 @@ public class Pawn extends Piece{
         Knight k = new Knight(true, false);
         Rook r = new Rook(true, false);
         Bishop b = new Bishop(true, false);
-        Piece p1 = p;
-        Piece p2 = k;
-        Piece p3 = r;
-        Piece p4 = b;
-        System.out.println(Arrays.toString(p1.getMoves(8)));
-        System.out.println(Arrays.toString(p2.getMoves(28)));
-        System.out.println(Arrays.toString(p3.getMoves(36)));
-        System.out.println(Arrays.toString(p4.getMoves(36)));
+        Piece[] pieces = new Piece[] {p, k, r, b};
+        int[] positions = new int[] {8, 28, 36, 36};
+
+        MoveList moveList = new MoveList(pieces.length, 24, 64);
+
+        for (int i = 0; i < pieces.length; i++) {
+            pieces[i].getMoves(positions[i], moveList);
+        }
+
+        System.out.println(Arrays.toString(moveList.getMovesArray()));
     }
 
 }

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Piece.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Piece.java
@@ -1,5 +1,6 @@
 package org.mxnik.forcechess.ChessLogic.Pieces;
 
+import org.mxnik.forcechess.ChessLogic.Moves.MoveList;
 import org.mxnik.forcechess.Util.Helper;
 
 import static org.mxnik.forcechess.Util.Helper.*;
@@ -35,15 +36,19 @@ public abstract class Piece {
         this.hasMoved = hasMoved;
     }
 
-    public byte[] getMoves(int pos){
+    public void getMoves(int pos, MoveList moveList){
+        moveList.startPiece();
         byte[] mSet = this.getMoveSet();
-        byte[] finalMoves = new byte[mSet.length];
-        // just sets moves == 0 if they're invalid searching for a better sol.
-        for (int i = 0; i < mSet.length; i++) {
-            int offset = mSet[i];
-            finalMoves[i] = (byte) (pos + mSet[i] * ((isValidMove(pos, pos+offset)? 1 : 0)));
+
+        for (byte moveOffset : mSet) {
+            int target = pos + moveOffset;
+            if (!isValidMove(pos, target)) {
+                continue;
+            }
+
+            moveList.startDirection();
+            moveList.addMove((byte) target);
         }
-        return finalMoves;
     }
 
 
@@ -75,5 +80,4 @@ public abstract class Piece {
         return sb.toString();
     }
 }
-
 

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Queen.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Queen.java
@@ -1,6 +1,7 @@
 package org.mxnik.forcechess.ChessLogic.Pieces;
 
 import org.mxnik.forcechess.ChessLogic.Board;
+import org.mxnik.forcechess.ChessLogic.Moves.MoveList;
 
 import static org.mxnik.forcechess.Util.Helper.*;
 import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
@@ -36,12 +37,10 @@ public class Queen extends Piece{
     }
 
     @Override
-    public byte[] getMoves(int pos) {
+    public void getMoves(int pos, MoveList moveList) {
         // code shaut hässlich aus ist aber nicht so uneffizient.
         // läuft immer noch O(N)
-
-        byte[] finalMs = new byte[moveSet.length];
-        int movePtr = 0;
+        moveList.startPiece();
 
         int dLeft = distanceLeftB(pos);
         int dTop = distanceTopB(pos);
@@ -49,45 +48,46 @@ public class Queen extends Piece{
         int dBott = distanceBottomB(pos);
 
 
+        moveList.startDirection();
         for (int i = 1; i <= dLeft; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * LEFT.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * LEFT.offset));
         }
+
+        moveList.startDirection();
         for (int i = 1; i <= (Board.sideLen - dLeft) - 1; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * RIGHT.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * RIGHT.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= dTop; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * UP.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * UP.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= (Board.sideLen - dTop) - 1 ; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * DOWN.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * DOWN.offset));
         }
 
         // lönge der Diagonale ist das minimum zwischen den seiten
 
+        moveList.startDirection();
         for (int i = 1; i <= Math.min(dLeft, dTop); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * UP_L.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * UP_L.offset));
         }
+
+        moveList.startDirection();
         for (int i = 1; i <= (Math.min(dRight, dTop)); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * UP_R.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * UP_R.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= Math.min(dBott, dRight); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * DOWN_R.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * DOWN_R.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= Math.min(dBott, dLeft); i++) {
-            finalMs[movePtr] = (byte) ( pos + i * DOWN_L.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * DOWN_L.offset));
         }
-        return finalMs;
     }
 }

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Rook.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Rook.java
@@ -1,6 +1,7 @@
 package org.mxnik.forcechess.ChessLogic.Pieces;
 
 import org.mxnik.forcechess.ChessLogic.Board;
+import org.mxnik.forcechess.ChessLogic.Moves.MoveList;
 
 import java.lang.reflect.Array;
 
@@ -36,34 +37,33 @@ public class Rook extends Piece {
      * @return ein byte arr mit allen move offsets
      */
     @Override
-    public byte[] getMoves(int pos) {
+    public void getMoves(int pos, MoveList moveList) {
         // code shaut hässlich aus ist aber nicht so uneffizient.
         // läuft immer noch O(N)
-
-        byte[] finalMs = new byte[moveSet.length];
-        int movePtr = 0;
+        moveList.startPiece();
 
         int dLeft = distanceLeftB(pos);
         int dTop = distanceTopB(pos);
+
+        moveList.startDirection();
         for (int i = 1; i <= dLeft; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * LEFT.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * LEFT.offset));
         }
+
+        moveList.startDirection();
         for (int i = 1; i <= (Board.sideLen - dLeft) - 1; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * RIGHT.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * RIGHT.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= dTop; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * UP.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * UP.offset));
         }
 
+        moveList.startDirection();
         for (int i = 1; i <= (Board.sideLen - dTop) - 1 ; i++) {
-            finalMs[movePtr] = (byte) ( pos + i * DOWN.offset);
-            movePtr ++;
+            moveList.addMove((byte) (pos + i * DOWN.offset));
         }
-        return finalMs;
     }
 
 


### PR DESCRIPTION
### Motivation
- Replace the old `getMoves` byte-array return pattern with an API that writes directly into a centralized `MoveList` so moves can be grouped by piece and direction and avoid extra allocations.
- Unify move-list population so the `Board` can delegate move generation to pieces which record moves in the required `startPiece`/`startDirection`/`addMove` format.

### Description
- Change `Piece#getMoves` signature to `public void getMoves(int pos, MoveList moveList)` and import `MoveList` where needed.
- Update sliding piece implementations (`Rook`, `Bishop`, `Queen`) to `startPiece()`, create per-direction buckets with `startDirection()` and append moves with `addMove(...)` instead of returning arrays.
- Update `Board.loadMoveFromPosition()` to call the new `getMoves(int, MoveList)` signature and delegate move-list population to each piece implementation.
- Adjust `Pawn` demo `main` to build a `MoveList` and invoke the new API to keep example/debug usage working.

### Testing
- Ran `./mvnw test -q`, but the Maven wrapper failed to download its distribution due to a network/socket error in the environment and did not complete.
- Ran `mvn test -q`, but Maven failed dependency/plugin resolution with a `403 Forbidden` from Maven Central, so automated unit tests could not be executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f03f6efcc83248d98a709dba39a1a)