### PR TITLE
Refresh piece move sets when board size changes and recalculate offsets on FEN load

### DIFF
--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Board.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Board.java
@@ -67,6 +67,8 @@ public class Board {
         kingBPos = KingPositions.second();
         turn = notation.readFenTurn();
         sideLen = notation.readSideLen();
+        MoveOffsets.calculateOffset(sideLen);
+        Piece.refreshMoveSets();
 
         for (int i = 0; i < board.length; i++) {
             Piece p = board[i];

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Bishop.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Bishop.java
@@ -10,7 +10,18 @@ import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
 
 public class Bishop extends Piece {
     public final static int dirCount = 4;
-    private final byte[] moveSet = new byte[(Board.sideLen - 1) * 2];
+    private static byte[] moveSet = new byte[(Board.sideLen - 1) * 2];
+    static {
+        refreshMoveSet();
+    }
+
+    static void refreshMoveSet() {
+        int size = (Board.sideLen - 1) * 2;
+        if (moveSet.length != size) {
+            moveSet = new byte[size];
+        }
+    }
+
     public Bishop( boolean color, boolean hasMoved) {
         super(PieceTypes.BISHOP, color, hasMoved);
     }

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/King.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/King.java
@@ -7,18 +7,23 @@ import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
 
 public class King extends Piece{
     public static final int dirCount = 10;
-    private final byte[] moveSet = {
-            UP.offset,
-            RIGHT.offset,
-            DOWN.offset,
-            LEFT.offset,
-            UP_R.offset,
-            UP_L.offset,
-            DOWN_R.offset,
-            DOWN_L.offset,
-            (byte) (RIGHT.offset*2),
-            (byte) (LEFT.offset*2)
-    };
+    private static final byte[] moveSet = new byte[dirCount];
+    static {
+        refreshMoveSet();
+    }
+
+    static void refreshMoveSet() {
+        moveSet[0] = UP.offset;
+        moveSet[1] = RIGHT.offset;
+        moveSet[2] = DOWN.offset;
+        moveSet[3] = LEFT.offset;
+        moveSet[4] = UP_R.offset;
+        moveSet[5] = UP_L.offset;
+        moveSet[6] = DOWN_R.offset;
+        moveSet[7] = DOWN_L.offset;
+        moveSet[8] = (byte) (RIGHT.offset * 2);
+        moveSet[9] = (byte) (LEFT.offset * 2);
+    }
 
     @Override
     public int getMaxDir() {

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Knight.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Knight.java
@@ -6,17 +6,21 @@ import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
 
 public class Knight extends Piece{
     public final static int dirCount = 8;
-    private final byte[] moveSet = {
-            (byte) (RIGHT.offset + UP.offset * 2),
-            (byte) (LEFT.offset + UP.offset * 2),
-            (byte) (RIGHT.offset + DOWN.offset * 2),
-            (byte) (LEFT.offset + DOWN.offset * 2),
+    private static final byte[] moveSet = new byte[dirCount];
+    static {
+        refreshMoveSet();
+    }
 
-            (byte) (RIGHT.offset * 2 + UP.offset),
-            (byte) (LEFT.offset * 2 + UP.offset),
-            (byte) (RIGHT.offset * 2 + DOWN.offset),
-            (byte) (LEFT.offset * 2+ DOWN.offset),
-    };
+    static void refreshMoveSet() {
+        moveSet[0] = (byte) (RIGHT.offset + UP.offset * 2);
+        moveSet[1] = (byte) (LEFT.offset + UP.offset * 2);
+        moveSet[2] = (byte) (RIGHT.offset + DOWN.offset * 2);
+        moveSet[3] = (byte) (LEFT.offset + DOWN.offset * 2);
+        moveSet[4] = (byte) (RIGHT.offset * 2 + UP.offset);
+        moveSet[5] = (byte) (LEFT.offset * 2 + UP.offset);
+        moveSet[6] = (byte) (RIGHT.offset * 2 + DOWN.offset);
+        moveSet[7] = (byte) (LEFT.offset * 2 + DOWN.offset);
+    }
 
     @Override
     public int getMaxDir() {

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Pawn.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Pawn.java
@@ -13,21 +13,22 @@ import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
 
 public class Pawn extends Piece{
     public final static int dirCount = 3;
-    public static final byte baseMove = UP.offset;
-    public static final byte doubleMove = (byte) (UP.offset * 2);
+    private static final byte[] moveSet = new byte[4];
+    private static final byte[] captureMoves = new byte[2];
+    static {
+        refreshMoveSet();
+    }
 
-    // to group all other moves in different directions
-    private static final byte[] otherMoves = {
-            UP_R.offset,
-            UP_L.offset
-    };
+    static void refreshMoveSet() {
+        moveSet[0] = UP.offset;
+        moveSet[1] = (byte) (UP.offset * 2);
+        moveSet[2] = UP_R.offset;
+        moveSet[3] = UP_L.offset;
 
-    private final byte[] moveSet = {
-            UP.offset,
-            (byte) (UP.offset * 2),
-            UP_R.offset,
-            UP_L.offset
-    };
+        captureMoves[0] = UP_R.offset;
+        captureMoves[1] = UP_L.offset;
+    }
+
     public Pawn(boolean color, boolean hasMoved) {
         super(PieceTypes.PAWN, color, hasMoved);
     }
@@ -78,9 +79,7 @@ public class Pawn extends Piece{
             moveList.addMoves((byte) target);
         }
 
-
-
-        for (byte moveOffset : otherMoves) {
+        for (byte moveOffset : captureMoves) {
             target = pos + moveOffset * ((color)? 1 : -1);
             if (!isValidMove(pos, target)) {
                 continue;

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Piece.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Piece.java
@@ -76,6 +76,15 @@ public abstract class Piece implements Cloneable {
         return type;
     }
 
+    public static void refreshMoveSets() {
+        Bishop.refreshMoveSet();
+        Rook.refreshMoveSet();
+        Queen.refreshMoveSet();
+        Knight.refreshMoveSet();
+        King.refreshMoveSet();
+        Pawn.refreshMoveSet();
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Piece{");
@@ -86,4 +95,3 @@ public abstract class Piece implements Cloneable {
         return sb.toString();
     }
 }
-

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Queen.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Queen.java
@@ -9,7 +9,17 @@ import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.DOWN;
 
 public class Queen extends Piece{
     public final static int dirCount = 8;
-    private final byte[] moveSet = new byte[(Board.sideLen - 1) * 4];
+    private static byte[] moveSet = new byte[(Board.sideLen - 1) * 4];
+    static {
+        refreshMoveSet();
+    }
+
+    static void refreshMoveSet() {
+        int size = (Board.sideLen - 1) * 4;
+        if (moveSet.length != size) {
+            moveSet = new byte[size];
+        }
+    }
 
     public Queen(boolean color, boolean hasMoved) {
         super(PieceTypes.QUEEN, color, hasMoved);

--- a/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Rook.java
+++ b/src/main/java/org/mxnik/forcechess/ChessLogic/Pieces/Rook.java
@@ -11,8 +11,18 @@ import static org.mxnik.forcechess.ChessLogic.Moves.MoveOffsets.*;
 
 public class Rook extends Piece {
     public final static int dirCount = 4;
-    // 7 (boardlen -1) in each cardinal direction
-    private final byte[] moveSet = new byte[(Board.sideLen - 1) * 2];
+    private static byte[] moveSet = new byte[(Board.sideLen - 1) * 2];
+    static {
+        refreshMoveSet();
+    }
+
+    static void refreshMoveSet() {
+        int size = (Board.sideLen - 1) * 2;
+        if (moveSet.length != size) {
+            moveSet = new byte[size];
+        }
+    }
+
     public Rook( boolean color, boolean hasMoved) {
         super(PieceTypes.ROOK, color, hasMoved);
     }


### PR DESCRIPTION
### Motivation

- Ensure piece move tables adapt to dynamic board sizes by recreating/resizing move arrays when the board side length changes.
- Recompute move offsets after parsing a FEN so move offsets and piece move sets remain consistent for non-standard board sizes.
- Simplify pawn capture handling by making capture offsets explicit and re-usable.

### Description

- Converted per-instance `moveSet` definitions for `Bishop`, `Rook`, `Queen`, `King`, and `Knight` into static arrays with `refreshMoveSet()` methods that resize the arrays to `(Board.sideLen - 1) * N` as needed.  
- Added `Piece.refreshMoveSets()` to centrally invoke all piece `refreshMoveSet()` methods and made `BuildFromFen` call `MoveOffsets.calculateOffset(sideLen)` and `Piece.refreshMoveSets()` after reading `sideLen`.  
- Updated `Pawn` to use a static `moveSet` and a separate `captureMoves` array with a `refreshMoveSet()` routine, and switched pawn capture iteration to use `captureMoves`.  
- Kept piece behavior intact while making move tables updatable after FEN parsing so variable board sizes are supported without recreating piece instances.

### Testing

- Project was compiled successfully with `mvn -DskipTests package` to verify code changes integrate (build succeeded).  
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3def0f9688329b695f4aa48e67823)